### PR TITLE
Replace golang with go in markdown code blocks

### DIFF
--- a/docs/go-storage/pairs/index.md
+++ b/docs/go-storage/pairs/index.md
@@ -36,7 +36,7 @@ We will document all global pair here and leave service pairs in service's docum
 
 Any service that supports this mechanism will generate service pairs called  `DefaultServicePairs` and `DefaultStoragePairs`:
 
-```golang
+```go
 type DefaultStoragePairs struct {
 	CompleteMultipart []Pair
 	Create            []Pair
@@ -61,7 +61,7 @@ func WithDefaultStoragePairs(v DefaultStoragePairs) Pair {
 
 User can use pass default pairs like this:
 
-```golang
+```go
 store, err := s3.NewStorager(
     s3.WithDefaultStoragePairs(s3.DefaultStoragePairs{
         Write: []types.Pair{

--- a/docs/go-storage/pairs/pair_policy.md
+++ b/docs/go-storage/pairs/pair_policy.md
@@ -4,7 +4,7 @@
 
 `pair_policy` looks like:
 
-```golang
+```go
 type PairPolicy struct {
 	...
 	

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/go-storage/pairs/index.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/go-storage/pairs/index.md
@@ -36,7 +36,7 @@ We will document all global pair here and leave service pairs in service's docum
 
 Any service that supports this mechanism will generate service pairs called  `DefaultServicePairs` and `DefaultStoragePairs`:
 
-```golang
+```go
 type DefaultStoragePairs struct {
     CompleteMultipart []Pair
     Create            []Pair
@@ -61,7 +61,7 @@ func WithDefaultStoragePairs(v DefaultStoragePairs) Pair {
 
 User can use pass default pairs like this:
 
-```golang
+```go
 store, err := s3.NewStorager(
     s3.WithDefaultStoragePairs(s3.DefaultStoragePairs{
         Write: []types.Pair{

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/go-storage/pairs/pair_policy.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/go-storage/pairs/pair_policy.md
@@ -4,7 +4,7 @@
 
 `pair_policy` looks like:
 
-```golang
+```go
 type PairPolicy struct {
     ...
 


### PR DESCRIPTION
It seems docsarsus uses prism to render code blocks, and there's no alias for golang and we have go use `go`.
 https://prismjs.com/#supported-languages

Now some code blocks not rendered
![image](https://user-images.githubusercontent.com/37948597/116218365-087b9700-a77d-11eb-8669-586b28988927.png)
